### PR TITLE
fix config.sh sourcing

### DIFF
--- a/humans
+++ b/humans
@@ -4,11 +4,14 @@
 set -ue
 
 # Load configuration file
-if ! (source config.sh 2> /dev/null); then
-  echo >&2 "Could not find $(dirname "$0")/config.sh"
+config_file=$(dirname "$0")/config.sh
+if [ ! -f "$config_file" ]; then
+  echo >&2 "Could not find $config_file"
   echo >&2 "Run $(dirname "$0")/configure to create it"
   exit 1
 fi
+
+. "$config_file"
 
 # Create a temporary directory to store the repository
 dir="$(mktemp -d)"


### PR DESCRIPTION
1. Variables bound inside of `config.sh` are available only inside of
   expression `(source config.sh 2> /dev/null)`
2. `source` is not defined POSIX standart, so it's better to use `.`

---

Just as an example, running following script

```
set -ue
if ! (source config.sh && echo "owner in block: $owner"); then
  echo "failure"
  exit 1
fi

echo "owner outside of block: $owner"
exit 0
```

leads to following output:

```
$ ./humans 
owner in block: d12frosted
./humans: line 7: owner: unbound variable
```

---

Overall my solution looks not as elegant as original code, but fixes described issues. Let me know what you think 😸 